### PR TITLE
Add support for cache fallback_keys property

### DIFF
--- a/src/main/kotlin/pcimcioch/gitlabci/dsl/job/CacheDsl.kt
+++ b/src/main/kotlin/pcimcioch/gitlabci/dsl/job/CacheDsl.kt
@@ -32,6 +32,12 @@ class CacheDsl : DslBase() {
         get() = keyString ?: keyDsl
         private set
 
+    @SerialName("fallback_keys")
+    var fallbackKeys: MutableList<String>? = null
+
+    fun fallbackKeys(vararg elements: String) = fallbackKeys(elements.toList())
+    fun fallbackKeys(elements: Iterable<String>) = ensureFallbackKeys().addAll(elements)
+
     fun paths(vararg elements: String) = paths(elements.toList())
     fun paths(elements: Iterable<String>) = ensurePaths().addAll(elements)
 
@@ -52,9 +58,11 @@ class CacheDsl : DslBase() {
 
     override fun validate(errors: MutableList<String>) {
         addErrors(errors, "[cache]", keyDsl)
+        addError(errors, fallbackKeys != null && fallbackKeys!!.size > 5, "[cache] fallback_keys list can't have more than 5 elements")
     }
 
     private fun ensureKeyDsl() = keyDsl ?: CacheKeyDsl().also { keyDsl = it }
+    private fun ensureFallbackKeys() = fallbackKeys ?: mutableListOf<String>().also { fallbackKeys = it }
     private fun ensurePaths() = paths ?: mutableSetOf<String>().also { paths = it }
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -68,6 +76,7 @@ class CacheDsl : DslBase() {
         if (policy != other.policy) return false
         if (whenCache != other.whenCache) return false
         if (key != other.key) return false
+        if (fallbackKeys != other.fallbackKeys) return false
 
         return true
     }
@@ -79,6 +88,7 @@ class CacheDsl : DslBase() {
         result = 31 * result + (policy?.hashCode() ?: 0)
         result = 31 * result + (whenCache?.hashCode() ?: 0)
         result = 31 * result + (key?.hashCode() ?: 0)
+        result = 31 * result + (fallbackKeys?.hashCode() ?: 0)
         return result
     }
 

--- a/src/test/kotlin/pcimcioch/gitlabci/dsl/job/CacheDslTest.kt
+++ b/src/test/kotlin/pcimcioch/gitlabci/dsl/job/CacheDslTest.kt
@@ -30,6 +30,7 @@ internal class CacheDslTest : DslTestBase<CacheDsl>(CacheDsl.serializer()) {
             policy = CachePolicy.PULL_PUSH
             whenCache = WhenCacheType.ON_SUCCESS
             key("key1")
+            fallbackKeys("fallback1", "fallback2")
         }
 
         // then
@@ -44,6 +45,9 @@ internal class CacheDslTest : DslTestBase<CacheDsl>(CacheDsl.serializer()) {
                     policy: "pull-push"
                     when: "on_success"
                     key: "key1"
+                    fallback_keys:
+                    - "fallback1"
+                    - "fallback2"
                 """
         )
     }
@@ -290,6 +294,141 @@ internal class CacheDslTest : DslTestBase<CacheDsl>(CacheDsl.serializer()) {
     }
 
     @Test
+    fun `should create cache with empty fallback keys`() {
+        // given
+        val testee = createCache {
+            fallbackKeys()
+        }
+
+        // then
+        assertDsl(
+            testee,
+            """
+                    fallback_keys: []
+                """
+        )
+    }
+
+    @Test
+    fun `should create cache with single fallback key`() {
+        // given
+        val testee = createCache {
+            fallbackKeys("key1")
+        }
+
+        // then
+        assertDsl(
+            testee,
+            """
+                    fallback_keys:
+                    - "key1"
+                """
+        )
+    }
+
+    @Test
+    fun `should create cache with multiple fallback keys`() {
+        // given
+        val testee = createCache {
+            fallbackKeys("key1", "key2", "key3")
+        }
+
+        // then
+        assertDsl(
+            testee,
+            """
+                    fallback_keys:
+                    - "key1"
+                    - "key2"
+                    - "key3"
+                """
+        )
+    }
+
+    @Test
+    fun `should merge fallback keys`() {
+        // given
+        val testee = createCache {
+            fallbackKeys("key1", "key2")
+            fallbackKeys(listOf("key3", "key4"))
+        }
+
+        // then
+        assertDsl(
+            testee,
+            """
+                    fallback_keys:
+                    - "key1"
+                    - "key2"
+                    - "key3"
+                    - "key4"
+                """
+        )
+    }
+
+    @Test
+    fun `should allow direct access to fallback keys`() {
+        // given
+        val testee = createCache {
+            fallbackKeys = mutableListOf("key1", "key2")
+        }
+
+        // then
+        assertDsl(
+            testee,
+            """
+                    fallback_keys:
+                    - "key1"
+                    - "key2"
+                """
+        )
+    }
+
+    @Test
+    fun `should validate fallback keys max 5`() {
+        // given
+        val testee = createCache {
+            fallbackKeys("k1", "k2", "k3", "k4", "k5", "k6")
+        }
+
+        // then
+        assertDsl(
+            testee,
+            """
+                    fallback_keys:
+                    - "k1"
+                    - "k2"
+                    - "k3"
+                    - "k4"
+                    - "k5"
+                    - "k6"
+                """,
+            "[cache] fallback_keys list can't have more than 5 elements"
+        )
+    }
+
+    @Test
+    fun `should accept fallback keys with exactly 5`() {
+        // given
+        val testee = createCache {
+            fallbackKeys("k1", "k2", "k3", "k4", "k5")
+        }
+
+        // then
+        assertDsl(
+            testee,
+            """
+                    fallback_keys:
+                    - "k1"
+                    - "k2"
+                    - "k3"
+                    - "k4"
+                    - "k5"
+                """
+        )
+    }
+
+    @Test
     fun `should be equal`() {
         // given
         val testee = createCache {
@@ -301,6 +440,7 @@ internal class CacheDslTest : DslTestBase<CacheDsl>(CacheDsl.serializer()) {
                 prefix = "gottem"
                 files = mutableSetOf("file1", "file2")
             }
+            fallbackKeys("fb1", "fb2")
         }
 
         val expected = createCache {
@@ -312,6 +452,7 @@ internal class CacheDslTest : DslTestBase<CacheDsl>(CacheDsl.serializer()) {
                 prefix = "gottem"
                 files = mutableSetOf("file1", "file2")
             }
+            fallbackKeys("fb1", "fb2")
         }
 
         // then
@@ -327,6 +468,7 @@ internal class CacheDslTest : DslTestBase<CacheDsl>(CacheDsl.serializer()) {
             policy = CachePolicy.PULL_PUSH
             whenCache = WhenCacheType.ALWAYS
             key("k")
+            fallbackKeys("fb1")
         }
 
         val expected = createCache {
@@ -335,6 +477,7 @@ internal class CacheDslTest : DslTestBase<CacheDsl>(CacheDsl.serializer()) {
             policy = CachePolicy.PULL_PUSH
             whenCache = WhenCacheType.ALWAYS
             key("k")
+            fallbackKeys("fb1")
         }
 
         // then


### PR DESCRIPTION
## Summary

First off, thanks for building this DSL — it's a really clean way to manage GitLab CI configuration in Kotlin!

This PR adds support for the [`cache:fallback_keys`](https://docs.gitlab.com/ci/yaml/#cachefallback_keys) property, which allows specifying alternative cache keys to try when the primary key results in a cache miss.

## Motivation

Currently, achieving cache fallback behavior requires duplicating the entire cache block with a pull-only policy:

```kotlin
fun JobDsl.defaultCache(cachePolicy: CachePolicy) {
    cache(".gradle/wrapper", ".gradle/caches") {
        key(DefaultEnvironment.CI_COMMIT_REF_SLUG.unix())
        policy = cachePolicy
    }
    // Workaround: pull main's cache on cold branches
    cache(".gradle/wrapper", ".gradle/caches") {
        key("main")
        policy = CachePolicy.PULL
    }
}
```

This workaround not only duplicates configuration, but also forces downloading both caches every time — even when the primary key hits. With `fallback_keys`, GitLab only tries the fallback keys on a cache miss, and it simplifies to a single cache block:

```kotlin
fun JobDsl.defaultCache(cachePolicy: CachePolicy) {
    cache(".gradle/wrapper", ".gradle/caches") {
        key(DefaultEnvironment.CI_COMMIT_REF_SLUG.unix())
        fallbackKeys("main")
        policy = cachePolicy
    }
}
```

## Generated YAML

```yaml
cache:
  key: "$CI_COMMIT_REF_SLUG"
  fallback_keys:
    - "main"
  paths:
    - ".gradle/wrapper"
    - ".gradle/caches"
```

## What's included

- `fallbackKeys` property on `CacheDsl` (serialized as `fallback_keys`)
- Convenience methods: `fallbackKeys(vararg)`, `fallbackKeys(Iterable)`, and direct assignment
- Validation: max 5 keys per GitLab CI docs
- 7 new unit tests covering empty/single/multiple/merge/direct access/validation

## Test plan

- All 25 CacheDsl tests pass (`./gradlew test --tests "pcimcioch.gitlabci.dsl.job.CacheDslTest"`)